### PR TITLE
Исправлена ошибка в комментарии, он приведен в соответствие с кодом.

### DIFF
--- a/cs/HomeExercises/NumberValidatorTests.cs
+++ b/cs/HomeExercises/NumberValidatorTests.cs
@@ -45,7 +45,7 @@ namespace HomeExercises
 			if (precision <= 0)
 				throw new ArgumentException("precision must be a positive number");
 			if (scale < 0 || scale >= precision)
-				throw new ArgumentException("precision must be a non-negative number less or equal than precision");
+				throw new ArgumentException("scale must be a non-negative number less than precision");
 			numberRegex = new Regex(@"^([+-]?)(\d+)([.,](\d+))?$", RegexOptions.IgnoreCase);
 		}
 


### PR DESCRIPTION
В комментарии к коду дважды указано слово precision;
Так же сказано (после исправления), что scale ... must be less or equal ..., хотя код выше (if-statement) этому противоречит. 