### PR TITLE
Copy app.config if it was not copied

### DIFF
--- a/cs/Challenge/Challenge.csproj
+++ b/cs/Challenge/Challenge.csproj
@@ -143,4 +143,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="app.config" DestinationFiles="$(TargetDir)\Challenge.exe.config" Condition="!Exists('$(TargetDir)\Challenge.exe.config')" />
+  </Target>
 </Project>

--- a/cs/Challenge/Infrastructure/Program.cs
+++ b/cs/Challenge/Infrastructure/Program.cs
@@ -58,7 +58,7 @@ namespace Challenge.Infrastructure
             }
             catch(Exception e)
             {
-                Console.WriteLine(e.Message);
+                Console.WriteLine(e);
             }
         }
 


### PR DESCRIPTION
Почему-то у некоторых студентов студия не копирует app.config в Challenge.exe.config, из-за этого не срабатывает binding-редирект на Newtonsoft.Json и валится отправка результатов в Firebase.

До истинной причины докопаться не смог, поэтому просто копирую файл еще раз в конце мсбилдом, если его нет